### PR TITLE
Fix template error when generating basic auth

### DIFF
--- a/genny/auth/auth.go
+++ b/genny/auth/auth.go
@@ -60,6 +60,7 @@ func New(args []string) (*genny.Generator, error) {
 	ctx.Set("attrs", fields)
 
 	g.Transformer(plushgen.Transformer(ctx))
+	g.Transformer(genny.Replace(".html", ".plush.html"))
 	g.Transformer(genny.NewTransformer(".plush.html", newUserHTMLTransformer))
 	g.Transformer(genny.NewTransformer(".fizz", migrationsTransformer(time.Now())))
 

--- a/genny/auth/templates/templates/auth/new.plush.html
+++ b/genny/auth/templates/templates/auth/new.plush.html
@@ -19,10 +19,10 @@
   <div class="sign-form">
     <h1>Sign In</h1>
 
-    <%= form_for(user, {action: signinPath()}) { %>
-      <%= f.InputTag("Email") %>
-      <%= f.InputTag("Password", {type: "password"}) %>
+    \<%= form_for(user, {action: signinPath()}) { %>
+      \<%= f.InputTag("Email") %>
+      \<%= f.InputTag("Password", {type: "password"}) %>
       <button class="btn btn-success">Sign In!</button>
-    <% } %>
+    \<% } %>
   </div>
 </div>

--- a/genny/auth/templates/templates/index.plush.html
+++ b/genny/auth/templates/templates/index.plush.html
@@ -11,11 +11,11 @@
 </style>
 
 <div class="auth-center">
-  <%= if (current_user) { %>
-    <h1><%= current_user.Email %></h1>
+  \<%= if (current_user) { %>
+    <h1>\<%= current_user.Email %></h1>
     <a href="/signout" data-method="DELETE">Sign Out</a>
-  <% } else { %>
+  \<% } else { %>
     <a href="/signin" class="btn btn-primary">Sign In</a>
     <a href="/users/new" class="btn btn-success">Register</a>
-  <% } %>
+  \<% } %>
 </div>

--- a/genny/auth/templates/templates/users/new.plush.html
+++ b/genny/auth/templates/templates/users/new.plush.html
@@ -14,17 +14,17 @@
 
   .auth-wrapper h1{margin-bottom: 20px;}
 </style>
-  
+
 <div class="auth-wrapper">
   <div class="sign-form">
     <h1>Register</h1>
 
-    <%= form_for(user, {action: usersPath()}) { %>
-      <%= f.InputTag("Email") %>
-      <%= f.InputTag("Password", {type: "password"}) %>
-      <%= f.InputTag("PasswordConfirmation", {type: "password"}) %>
-      
+    \<%= form_for(user, {action: usersPath()}) { %>
+      \<%= f.InputTag("Email") %>
+      \<%= f.InputTag("Password", {type: "password"}) %>
+      \<%= f.InputTag("PasswordConfirmation", {type: "password"}) %>
+
       <button class="btn btn-success">Register!</button>
-    <% } %>
+    \<% } %>
   </div>
 </div>


### PR DESCRIPTION
This addresses the issue referenced here:
https://github.com/gobuffalo/buffalo-auth/issues/54

The problem is that we have .plush files that themselves generate
.plush files.  There are two required fixes:

By escaping the <% tags in the plush files themselves we can
seperate the tags that should be evaluated at the time of
the genny.Transform vs those that should be evaluted in the
context of the webapp.

Once the plush file escaping issue is dealt with we still have
the problem that plushgen strips the .plush. extensions from
the file names (leaving new.html instead of new.plush.html).
I've added a new transform in the pipeline to rename ".html"
files back to ".plush.html" so that they will have the
appropriate file extention in the destination project.